### PR TITLE
Update adapter ID prefix to 'nx' and add Nexo dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,6 +112,7 @@ project(":plugin") {
 
 dependencies {
     implementation(project(":oraxen-j21"))
+    implementation(project(":nexo-j21"))
     implementation(project(":plugin"))
 }
 

--- a/nexo-j21/src/main/java/dev/wuason/storagemechanic/storages/types/block/compatibilities/NexoEvents.java
+++ b/nexo-j21/src/main/java/dev/wuason/storagemechanic/storages/types/block/compatibilities/NexoEvents.java
@@ -20,7 +20,7 @@ public class NexoEvents implements Listener {
     public void onInteractNexoBlock(NexoNoteBlockInteractEvent event) {
         if (event.getPlayer().isSneaking()) return;
         if (event.getHand() == null || !event.getHand().equals(EquipmentSlot.HAND)) return;
-        String adapterId = "nexo:" + event.getMechanic().getItemID();
+        String adapterId = "nx:" + event.getMechanic().getItemID();
         blockStorageManager.onBlockInteract(event.getBlock(), event.getItemInHand(), event.getPlayer(), event, Action.RIGHT_CLICK_BLOCK, adapterId);
     }
 
@@ -28,7 +28,7 @@ public class NexoEvents implements Listener {
     public void onInteractNexoBlockString(NexoStringBlockInteractEvent event) {
         if (event.getPlayer().isSneaking()) return;
         if (event.getHand() == null || !event.getHand().equals(EquipmentSlot.HAND)) return;
-        String adapterId = "nexo:" + event.getMechanic().getItemID();
+        String adapterId = "nx:" + event.getMechanic().getItemID();
         blockStorageManager.onBlockInteract(event.getBlock(), event.getItemInHand(), event.getPlayer(), event, Action.RIGHT_CLICK_BLOCK, adapterId);
     }
 }

--- a/nexo-j21/src/main/java/dev/wuason/storagemechanic/storages/types/furnitures/compatibilities/NexoFurnitureEvents.java
+++ b/nexo-j21/src/main/java/dev/wuason/storagemechanic/storages/types/furnitures/compatibilities/NexoFurnitureEvents.java
@@ -11,7 +11,7 @@ import org.bukkit.event.Listener;
 
 public class NexoFurnitureEvents implements Listener {
 
-    private final String ADAPTER_TYPE = "nexo:";
+    private final String ADAPTER_TYPE = "nx:";
     private FurnitureStorageManager furnitureStorageManager;
 
     public NexoFurnitureEvents(FurnitureStorageManager furnitureStorageManager) {

--- a/plugin/src/main/java/dev/wuason/storagemechanic/storages/types/block/BlockStorageManager.java
+++ b/plugin/src/main/java/dev/wuason/storagemechanic/storages/types/block/BlockStorageManager.java
@@ -443,7 +443,7 @@ public class BlockStorageManager implements Listener {
                                     persistentDataContainer.set(namespacedKey, PersistentDataType.STRING, blockStorage.getId() + ":" + blockStorage.getBlockStorageConfigID() + ":" + blockStorage.getOwnerUUID());
                                 }
                             }
-                            if (adapterID.contains("or:") || adapterID.contains("mc:") || adapterID.contains("sm:") || adapterID.contains("mmoitems:") || adapterID.contains("eb:") || adapterID.contains("mythiccrucible:")) {
+                            if (adapterID.contains("or:") || adapterID.contains("mc:") || adapterID.contains("sm:") || adapterID.contains("mmoitems:") || adapterID.contains("eb:") || adapterID.contains("mythiccrucible:") || adapterID.contains("nx:")) {
                                 openBlockStorage(blockStorage.getId(), player);
                             }
                         }


### PR DESCRIPTION
Replaced the 'nexo:' adapter ID prefix with 'nx:' across relevant classes to standardize the prefix. Also added the ':nexo-j21' project as a dependency in the build configuration. These changes improve consistency and ensure proper integration of Nexo functionality.